### PR TITLE
Fix for mybinder failing to compile

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - python=3.11.*
+  - python=3.10.*
   - numpy=1.24.*
   - matplotlib=3.7.*
   - webio-jupyter-extension=0.1.*

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - python=3.11.0
-  - numpy=1.24.3
-  - matplotlib=3.7.1
-  - webio-jupyter-extension=0.1.0
-  - notebook=6.5.2
+  - python=3.11.*
+  - numpy=1.24.*
+  - matplotlib=3.7.*
+  - webio-jupyter-extension=0.1.*
+  - notebook=6.5.*


### PR DESCRIPTION
Downgrading python 3.11 -> python 3.10 fixes the issues with mamba at https://discourse.jupyter.org/t/mybinder-stopped-working-for-repo/21170